### PR TITLE
manifest: don't remove broadcom libbt

### DIFF
--- a/snippets/evolution.xml
+++ b/snippets/evolution.xml
@@ -86,7 +86,6 @@
   <remove-project name="device/ti/beagle-x15" />
   <remove-project name="device/ti/beagle-x15-kernel" />
 
-  <remove-project name="platform/hardware/broadcom/libbt" />
   <remove-project name="platform/hardware/google/pixel" />
   <remove-project name="platform/hardware/qcom/audio" />
   <remove-project name="platform/hardware/qcom/data/ipacfg-mgr" />


### PR DESCRIPTION
this commit fixes Bluetooth on Samsung Galaxy S10/N10 Series, because this lib was missing and made Bluetooth crash